### PR TITLE
Add tests and some types

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,22 @@
+name: test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    name: ${{ matrix.os }} / ruby ${{ matrix.ruby }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-14, ubuntu-latest]
+        ruby: ["3.3", "3.4"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+      - run: rake test

--- a/README.md
+++ b/README.md
@@ -48,8 +48,9 @@ the extension, and install it.
 
 ## Supported types
 
-`void`, `int`, `uint`, `long`, `size_t`, `float`, `double`, `string`, `pointer`,
-`bool`, `char`, `uchar`
+`void`, `int`, `uint`, `long`, `ulong`, `size_t`, `float`, `double`, `string`,
+`pointer`, `bool`, `char`, `uchar`, `short`, `ushort`, `int8`, `uint8`, `int16`,
+`uint16`, `int32`, `uint32`, `int64`, `uint64`, `long_long`, `ulong_long`
 
 ## How it works
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ the extension, and install it.
 
 ## Supported types
 
-`void`, `int`, `uint`, `long`, `size_t`, `float`, `double`, `string`, `pointer`
+`void`, `int`, `uint`, `long`, `size_t`, `float`, `double`, `string`, `pointer`,
+`bool`, `char`, `uchar`
 
 ## How it works
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,10 @@
+require "rake/testtask"
+
+Rake::TestTask.new(:test) do |t|
+  t.libs << "test"
+  t.libs << "."
+  t.test_files = FileList["test/**/test_*.rb"]
+  t.warning = false
+end
+
+task default: :test

--- a/ffx.rb
+++ b/ffx.rb
@@ -10,18 +10,31 @@
 #
 module FFX
   TYPES = {
-    void:   { byte:  0, c_type: "void" },
-    int:    { byte:  1, c_type: "int",           to_c: "NUM2INT(%s)",                  from_c: "INT2NUM(%s)" },
-    long:   { byte:  2, c_type: "long",          to_c: "NUM2LONG(%s)",                 from_c: "LONG2NUM(%s)" },
-    string: { byte:  3, c_type: "const char *",  to_c: "StringValueCStr(%s)",          from_c: "rb_str_new_cstr(%s)" },
-    uint:   { byte:  4, c_type: "unsigned int",  to_c: "NUM2UINT(%s)",                 from_c: "UINT2NUM(%s)" },
-    size_t: { byte:  5, c_type: "size_t",        to_c: "NUM2SIZET(%s)",                from_c: "SIZET2NUM(%s)" },
-    double: { byte:  6, c_type: "double",        to_c: "NUM2DBL(%s)",                  from_c: "DBL2NUM(%s)" },
-    float:  { byte:  7, c_type: "float",         to_c: "(float)NUM2DBL(%s)",           from_c: "DBL2NUM((double)%s)" },
-    pointer:{ byte:  8, c_type: "void *",        to_c: "(void *)NUM2ULL(%s)",          from_c: "ULL2NUM((unsigned long long)%s)" },
-    bool:   { byte:  9, c_type: "bool",          to_c: "(RTEST(%s) ? true : false)",   from_c: "((%s) ? Qtrue : Qfalse)" },
-    char:   { byte: 10, c_type: "char",          to_c: "(char)NUM2INT(%s)",            from_c: "INT2NUM((int)%s)" },
-    uchar:  { byte: 11, c_type: "unsigned char", to_c: "(unsigned char)NUM2UINT(%s)",  from_c: "UINT2NUM((unsigned int)%s)" },
+    void:       { byte:  0, c_type: "void" },
+    int:        { byte:  1, c_type: "int",                to_c: "NUM2INT(%s)",                   from_c: "INT2NUM(%s)" },
+    long:       { byte:  2, c_type: "long",               to_c: "NUM2LONG(%s)",                  from_c: "LONG2NUM(%s)" },
+    string:     { byte:  3, c_type: "const char *",       to_c: "StringValueCStr(%s)",           from_c: "rb_str_new_cstr(%s)" },
+    uint:       { byte:  4, c_type: "unsigned int",       to_c: "NUM2UINT(%s)",                  from_c: "UINT2NUM(%s)" },
+    size_t:     { byte:  5, c_type: "size_t",             to_c: "NUM2SIZET(%s)",                 from_c: "SIZET2NUM(%s)" },
+    double:     { byte:  6, c_type: "double",             to_c: "NUM2DBL(%s)",                   from_c: "DBL2NUM(%s)" },
+    float:      { byte:  7, c_type: "float",              to_c: "(float)NUM2DBL(%s)",            from_c: "DBL2NUM((double)%s)" },
+    pointer:    { byte:  8, c_type: "void *",             to_c: "(void *)NUM2ULL(%s)",           from_c: "ULL2NUM((unsigned long long)%s)" },
+    bool:       { byte:  9, c_type: "bool",               to_c: "(RTEST(%s) ? true : false)",    from_c: "((%s) ? Qtrue : Qfalse)" },
+    char:       { byte: 10, c_type: "char",               to_c: "(char)NUM2INT(%s)",             from_c: "INT2NUM((int)%s)" },
+    uchar:      { byte: 11, c_type: "unsigned char",      to_c: "(unsigned char)NUM2UINT(%s)",   from_c: "UINT2NUM((unsigned int)%s)" },
+    short:      { byte: 12, c_type: "short",              to_c: "(short)NUM2INT(%s)",            from_c: "INT2NUM((int)%s)" },
+    ushort:     { byte: 13, c_type: "unsigned short",     to_c: "(unsigned short)NUM2UINT(%s)",  from_c: "UINT2NUM((unsigned int)%s)" },
+    int8:       { byte: 14, c_type: "int8_t",             to_c: "(int8_t)NUM2INT(%s)",           from_c: "INT2NUM((int)%s)" },
+    uint8:      { byte: 15, c_type: "uint8_t",            to_c: "(uint8_t)NUM2UINT(%s)",         from_c: "UINT2NUM((unsigned int)%s)" },
+    int16:      { byte: 16, c_type: "int16_t",            to_c: "(int16_t)NUM2INT(%s)",          from_c: "INT2NUM((int)%s)" },
+    uint16:     { byte: 17, c_type: "uint16_t",           to_c: "(uint16_t)NUM2UINT(%s)",        from_c: "UINT2NUM((unsigned int)%s)" },
+    int32:      { byte: 18, c_type: "int32_t",            to_c: "(int32_t)NUM2INT(%s)",          from_c: "INT2NUM((int)%s)" },
+    uint32:     { byte: 19, c_type: "uint32_t",           to_c: "(uint32_t)NUM2UINT(%s)",        from_c: "UINT2NUM((unsigned int)%s)" },
+    int64:      { byte: 20, c_type: "int64_t",            to_c: "(int64_t)NUM2LL(%s)",           from_c: "LL2NUM((long long)%s)" },
+    uint64:     { byte: 21, c_type: "uint64_t",           to_c: "(uint64_t)NUM2ULL(%s)",         from_c: "ULL2NUM((unsigned long long)%s)" },
+    long_long:  { byte: 22, c_type: "long long",          to_c: "NUM2LL(%s)",                    from_c: "LL2NUM(%s)" },
+    ulong_long: { byte: 23, c_type: "unsigned long long", to_c: "NUM2ULL(%s)",                   from_c: "ULL2NUM(%s)" },
+    ulong:      { byte: 24, c_type: "unsigned long",      to_c: "NUM2ULONG(%s)",                 from_c: "ULONG2NUM(%s)" },
   }
 
   @modules = {}
@@ -122,6 +135,7 @@ module FFX
       c << "#include <string.h>\n"
       c << "#include <stdlib.h>\n"
       c << "#include <stdbool.h>\n"
+      c << "#include <stdint.h>\n"
       c << "#include <math.h>\n"
       Array(@headers).each { |h| c << "#include <#{h}>\n" }
       c << "\n"

--- a/ffx.rb
+++ b/ffx.rb
@@ -10,15 +10,18 @@
 #
 module FFX
   TYPES = {
-    void:   { byte: 0, c_type: "void" },
-    int:    { byte: 1, c_type: "int",          to_c: "NUM2INT(%s)",         from_c: "INT2NUM(%s)" },
-    long:   { byte: 2, c_type: "long",         to_c: "NUM2LONG(%s)",        from_c: "LONG2NUM(%s)" },
-    string: { byte: 3, c_type: "const char *", to_c: "StringValueCStr(%s)", from_c: "rb_str_new_cstr(%s)" },
-    uint:   { byte: 4, c_type: "unsigned int", to_c: "NUM2UINT(%s)",        from_c: "UINT2NUM(%s)" },
-    size_t: { byte: 5, c_type: "size_t",       to_c: "NUM2SIZET(%s)",       from_c: "SIZET2NUM(%s)" },
-    double: { byte: 6, c_type: "double",       to_c: "NUM2DBL(%s)",         from_c: "DBL2NUM(%s)" },
-    float:  { byte: 7, c_type: "float",        to_c: "(float)NUM2DBL(%s)",  from_c: "DBL2NUM((double)%s)" },
-    pointer:{ byte: 8, c_type: "void *",       to_c: "(void *)NUM2ULL(%s)", from_c: "ULL2NUM((unsigned long long)%s)" },
+    void:   { byte:  0, c_type: "void" },
+    int:    { byte:  1, c_type: "int",           to_c: "NUM2INT(%s)",                  from_c: "INT2NUM(%s)" },
+    long:   { byte:  2, c_type: "long",          to_c: "NUM2LONG(%s)",                 from_c: "LONG2NUM(%s)" },
+    string: { byte:  3, c_type: "const char *",  to_c: "StringValueCStr(%s)",          from_c: "rb_str_new_cstr(%s)" },
+    uint:   { byte:  4, c_type: "unsigned int",  to_c: "NUM2UINT(%s)",                 from_c: "UINT2NUM(%s)" },
+    size_t: { byte:  5, c_type: "size_t",        to_c: "NUM2SIZET(%s)",                from_c: "SIZET2NUM(%s)" },
+    double: { byte:  6, c_type: "double",        to_c: "NUM2DBL(%s)",                  from_c: "DBL2NUM(%s)" },
+    float:  { byte:  7, c_type: "float",         to_c: "(float)NUM2DBL(%s)",           from_c: "DBL2NUM((double)%s)" },
+    pointer:{ byte:  8, c_type: "void *",        to_c: "(void *)NUM2ULL(%s)",          from_c: "ULL2NUM((unsigned long long)%s)" },
+    bool:   { byte:  9, c_type: "bool",          to_c: "(RTEST(%s) ? true : false)",   from_c: "((%s) ? Qtrue : Qfalse)" },
+    char:   { byte: 10, c_type: "char",          to_c: "(char)NUM2INT(%s)",            from_c: "INT2NUM((int)%s)" },
+    uchar:  { byte: 11, c_type: "unsigned char", to_c: "(unsigned char)NUM2UINT(%s)",  from_c: "UINT2NUM((unsigned int)%s)" },
   }
 
   @modules = {}
@@ -68,7 +71,7 @@ module FFX
 
         @modules.each_value do |data|
           data[:functions].each do |f|
-            abort "missing function: #{f[:name]}" unless have_func(f[:name].to_s)
+            abort "missing function: #{f[:name]}" unless have_func(f[:name].to_s, @headers)
           end
         end
 
@@ -118,6 +121,7 @@ module FFX
       c << "#include <ruby.h>\n"
       c << "#include <string.h>\n"
       c << "#include <stdlib.h>\n"
+      c << "#include <stdbool.h>\n"
       c << "#include <math.h>\n"
       Array(@headers).each { |h| c << "#include <#{h}>\n" }
       c << "\n"

--- a/test/test_ffx.rb
+++ b/test/test_ffx.rb
@@ -96,6 +96,98 @@ class TestFFX < Minitest::Test
     end
   end
 
+  def test_remaining_primitives_round_trip
+    Dir.mktmpdir do |tmpdir|
+      FileUtils.cp(File.join(ROOT, "ffx.rb"), tmpdir)
+      FileUtils.cp(File.join(ROOT, "ffi.rb"), tmpdir)
+
+      File.write(File.join(tmpdir, "ffxtest.h"), <<~C)
+        #pragma once
+        #include <stdint.h>
+
+        static inline short              ffxtest_inc_short(short s)              { return (short)(s + 1); }
+        static inline unsigned short     ffxtest_inc_ushort(unsigned short s)    { return (unsigned short)(s + 1); }
+        static inline int8_t             ffxtest_inc_int8(int8_t n)              { return (int8_t)(n + 1); }
+        static inline uint8_t            ffxtest_inc_uint8(uint8_t n)            { return (uint8_t)(n + 1); }
+        static inline int16_t            ffxtest_inc_int16(int16_t n)            { return (int16_t)(n + 1); }
+        static inline uint16_t           ffxtest_inc_uint16(uint16_t n)          { return (uint16_t)(n + 1); }
+        static inline int32_t            ffxtest_inc_int32(int32_t n)            { return n + 1; }
+        static inline uint32_t           ffxtest_inc_uint32(uint32_t n)          { return n + 1; }
+        static inline int64_t            ffxtest_inc_int64(int64_t n)            { return n + 1; }
+        static inline uint64_t           ffxtest_inc_uint64(uint64_t n)          { return n + 1; }
+        static inline long long          ffxtest_inc_ll(long long n)             { return n + 1; }
+        static inline unsigned long long ffxtest_inc_ull(unsigned long long n)   { return n + 1; }
+        static inline unsigned long      ffxtest_inc_ulong(unsigned long n)      { return n + 1; }
+      C
+
+      File.write(File.join(tmpdir, "mylib.rb"), <<~RUBY)
+        require "ffi"
+
+        module MyLib
+          extend FFI::Library
+          ffi_lib "c"
+
+          attach_function :ffxtest_inc_short,  [:short],      :short
+          attach_function :ffxtest_inc_ushort, [:ushort],     :ushort
+          attach_function :ffxtest_inc_int8,   [:int8],       :int8
+          attach_function :ffxtest_inc_uint8,  [:uint8],      :uint8
+          attach_function :ffxtest_inc_int16,  [:int16],      :int16
+          attach_function :ffxtest_inc_uint16, [:uint16],     :uint16
+          attach_function :ffxtest_inc_int32,  [:int32],      :int32
+          attach_function :ffxtest_inc_uint32, [:uint32],     :uint32
+          attach_function :ffxtest_inc_int64,  [:int64],      :int64
+          attach_function :ffxtest_inc_uint64, [:uint64],     :uint64
+          attach_function :ffxtest_inc_ll,     [:long_long],  :long_long
+          attach_function :ffxtest_inc_ull,    [:ulong_long], :ulong_long
+          attach_function :ffxtest_inc_ulong,  [:ulong],      :ulong
+        end
+      RUBY
+
+      File.write(File.join(tmpdir, "extconf.rb"), <<~RUBY)
+        require "mkmf"
+        $INCFLAGS << " -I" << __dir__
+        require_relative "ffx"
+        FFX.create_makefile("mylib", File.expand_path("mylib.rb", __dir__),
+                            headers: ["ffxtest.h"])
+      RUBY
+
+      build_extension(tmpdir)
+
+      ext_path = File.join(tmpdir, "mylib.#{DLEXT}")
+      out = run_ruby(tmpdir, <<~RUBY)
+        require "#{ext_path}"
+        puts MyLib.ffxtest_inc_short(30_000)
+        puts MyLib.ffxtest_inc_ushort(60_000)
+        puts MyLib.ffxtest_inc_int8(100)
+        puts MyLib.ffxtest_inc_uint8(250)
+        puts MyLib.ffxtest_inc_int16(30_000)
+        puts MyLib.ffxtest_inc_uint16(60_000)
+        puts MyLib.ffxtest_inc_int32(2_000_000_000)
+        puts MyLib.ffxtest_inc_uint32(4_000_000_000)
+        puts MyLib.ffxtest_inc_int64(5_000_000_000_000)
+        puts MyLib.ffxtest_inc_uint64(18_000_000_000_000_000_000)
+        puts MyLib.ffxtest_inc_ll(5_000_000_000_000)
+        puts MyLib.ffxtest_inc_ull(18_000_000_000_000_000_000)
+        puts MyLib.ffxtest_inc_ulong(4_000_000_000)
+      RUBY
+
+      lines = out.lines.map(&:chomp)
+      assert_equal "30001",                lines[0]
+      assert_equal "60001",                lines[1]
+      assert_equal "101",                  lines[2]
+      assert_equal "251",                  lines[3]
+      assert_equal "30001",                lines[4]
+      assert_equal "60001",                lines[5]
+      assert_equal "2000000001",           lines[6]
+      assert_equal "4000000001",           lines[7]
+      assert_equal "5000000000001",        lines[8]
+      assert_equal "18000000000000000001", lines[9]
+      assert_equal "5000000000001",        lines[10]
+      assert_equal "18000000000000000001", lines[11]
+      assert_equal "4000000001",           lines[12]
+    end
+  end
+
   private
 
   def build_extension(dir)

--- a/test/test_ffx.rb
+++ b/test/test_ffx.rb
@@ -1,0 +1,117 @@
+require "minitest/autorun"
+require "tmpdir"
+require "fileutils"
+require "rbconfig"
+
+class TestFFX < Minitest::Test
+  ROOT = File.expand_path("..", __dir__)
+  DLEXT = RbConfig::CONFIG["DLEXT"]
+
+  def test_strlen_end_to_end
+    Dir.mktmpdir do |tmpdir|
+      FileUtils.cp(File.join(ROOT, "ffx.rb"), tmpdir)
+      FileUtils.cp(File.join(ROOT, "ffi.rb"), tmpdir)
+
+      File.write(File.join(tmpdir, "mylib.rb"), <<~RUBY)
+        require "ffi"
+
+        module MyLib
+          extend FFI::Library
+          ffi_lib "c"
+
+          attach_function :strlen, [:string], :size_t
+        end
+      RUBY
+
+      File.write(File.join(tmpdir, "extconf.rb"), <<~RUBY)
+        require_relative "ffx"
+        FFX.create_makefile("mylib", File.expand_path("mylib.rb", __dir__))
+      RUBY
+
+      build_extension(tmpdir)
+
+      ext_path = File.join(tmpdir, "mylib.#{DLEXT}")
+      out = run_ruby(tmpdir, <<~RUBY)
+        require "#{ext_path}"
+        puts MyLib.strlen("hello")
+      RUBY
+
+      assert_equal "5", out.strip
+    end
+  end
+
+  def test_bool_char_uchar_round_trip
+    Dir.mktmpdir do |tmpdir|
+      FileUtils.cp(File.join(ROOT, "ffx.rb"), tmpdir)
+      FileUtils.cp(File.join(ROOT, "ffi.rb"), tmpdir)
+
+      File.write(File.join(tmpdir, "ffxtest.h"), <<~C)
+        #pragma once
+        #include <stdbool.h>
+
+        static inline bool          ffxtest_not_bool(bool b)         { return !b; }
+        static inline char          ffxtest_inc_char(char c)         { return (char)(c + 1); }
+        static inline unsigned char ffxtest_inc_uchar(unsigned char c){ return (unsigned char)(c + 1); }
+      C
+
+      File.write(File.join(tmpdir, "mylib.rb"), <<~RUBY)
+        require "ffi"
+
+        module MyLib
+          extend FFI::Library
+          ffi_lib "c"
+
+          attach_function :ffxtest_not_bool,  [:bool],  :bool
+          attach_function :ffxtest_inc_char,  [:char],  :char
+          attach_function :ffxtest_inc_uchar, [:uchar], :uchar
+        end
+      RUBY
+
+      File.write(File.join(tmpdir, "extconf.rb"), <<~RUBY)
+        require "mkmf"
+        $INCFLAGS << " -I" << __dir__
+        require_relative "ffx"
+        FFX.create_makefile("mylib", File.expand_path("mylib.rb", __dir__),
+                            headers: ["ffxtest.h"])
+      RUBY
+
+      build_extension(tmpdir)
+
+      ext_path = File.join(tmpdir, "mylib.#{DLEXT}")
+      out = run_ruby(tmpdir, <<~RUBY)
+        require "#{ext_path}"
+        puts MyLib.ffxtest_not_bool(true).inspect
+        puts MyLib.ffxtest_not_bool(false).inspect
+        puts MyLib.ffxtest_not_bool(nil).inspect
+        puts MyLib.ffxtest_inc_char(65)
+        puts MyLib.ffxtest_inc_uchar(254)
+      RUBY
+
+      lines = out.lines.map(&:chomp)
+      assert_equal "false", lines[0]
+      assert_equal "true",  lines[1]
+      assert_equal "true",  lines[2]   # nil is RTEST-falsy → !false → true
+      assert_equal "66",    lines[3]   # 'A' + 1 == 'B'
+      assert_equal "255",   lines[4]
+    end
+  end
+
+  private
+
+  def build_extension(dir)
+    Dir.chdir(dir) do
+      assert system(RbConfig.ruby, "extconf.rb", out: File::NULL),
+        "extconf.rb failed in #{dir}"
+      assert system("make", out: File::NULL),
+        "make failed in #{dir}"
+    end
+  end
+
+  def run_ruby(dir, script)
+    Dir.chdir(dir) do
+      out = IO.popen([RbConfig.ruby, "-e", script], &:read)
+      assert $?.success?, "ruby subprocess failed (#{$?}):\n#{out}"
+      out
+    end
+  end
+end


### PR DESCRIPTION
This pull requests adds integer primitive types, and tests.

I aim to add supoprt for more types, so that we could use it for `libddwaf` gem (which is a direct dependency of `datadog` gem).