### PR TITLE
Use function address instead of name in ZJIT metadata

### DIFF
--- a/ffx.rb
+++ b/ffx.rb
@@ -195,6 +195,15 @@ module FFX
       }.join
 
       <<~C
+        /*
+         * Storing the native function address directly would require a
+         * relocation in read-only section .text, forcing DT_TEXTREL and making the
+         * segment writable at load time. Instead we store an to a static variable;
+         * ZJIT resolves the offset to get
+         * the variable's address and dereferences it to obtain the function
+         * pointer. Using a variable also lets us to use a consistent
+         * underscore-prefixed name on all platforms
+         */
         __attribute__((used))
         static void *#{ptr_var} __asm__("_#{ptr_var}") = (void *)#{name};
 
@@ -207,7 +216,7 @@ module FFX
           ".long 0x46464930\\n"
           ".byte #{params.size}\\n"
         #{pbytes}  ".byte #{TYPES.fetch(ret)[:byte]}\\n"
-          ".long _#{ptr_var} - .\\n"
+          ".long _#{ptr_var} - .\\n"  /* PC-relative offset to ptr_var */
         );
         }
 

--- a/ffx.rb
+++ b/ffx.rb
@@ -188,12 +188,16 @@ module FFX
       name = f[:name]
       params = f[:params]
       ret = f[:ret]
+      ptr_var = "rb_#{prefix}_#{name}_fptr"
 
       pbytes = params.map { |t|
         "  \".byte #{TYPES.fetch(t)[:byte]}\\n\"\n"
       }.join
 
       <<~C
+        __attribute__((used))
+        static void *#{ptr_var} __asm__("_#{ptr_var}") = (void *)#{name};
+
         __attribute__((naked, aligned(16)))
         static VALUE
         rb_#{prefix}_#{name}(#{vparams(f)})
@@ -203,7 +207,7 @@ module FFX
           ".long 0x46464930\\n"
           ".byte #{params.size}\\n"
         #{pbytes}  ".byte #{TYPES.fetch(ret)[:byte]}\\n"
-          ".asciz \\"#{name}\\"\\n"
+          ".long _#{ptr_var} - .\\n"
         );
         }
 

--- a/test/test_ffx.rb
+++ b/test/test_ffx.rb
@@ -188,6 +188,44 @@ class TestFFX < Minitest::Test
     end
   end
 
+  def test_zjit_ffi_call
+    # Run with RUBY_ZJIT_ENABLE=1
+    skip "ZJIT not enabled" unless (defined?(RubyVM::ZJIT) && RubyVM::ZJIT.enabled?)
+
+    Dir.mktmpdir do |tmpdir|
+      FileUtils.cp(File.join(ROOT, "ffx.rb"), tmpdir)
+      FileUtils.cp(File.join(ROOT, "ffi.rb"), tmpdir)
+
+      File.write(File.join(tmpdir, "mylib.rb"), <<~RUBY)
+        require "ffi"
+
+        module MyLib
+          extend FFI::Library
+          ffi_lib "c"
+
+          attach_function :strlen, [:string], :size_t
+        end
+      RUBY
+
+      File.write(File.join(tmpdir, "extconf.rb"), <<~RUBY)
+        require_relative "ffx"
+        FFX.create_makefile("mylib", File.expand_path("mylib.rb", __dir__))
+      RUBY
+
+      build_extension(tmpdir)
+
+      ext_path = File.join(tmpdir, "mylib.#{DLEXT}")
+      out = run_ruby(tmpdir, <<~RUBY)
+        raise "ZJIT not enabled" unless (defined?(RubyVM::ZJIT) && RubyVM::ZJIT.enabled?)
+
+        require "#{ext_path}"
+        100.times { puts MyLib.strlen("hello") }
+      RUBY
+
+      assert_equal ["5"] * 100, out.lines.map(&:strip)
+    end
+  end
+
   private
 
   def build_extension(dir)


### PR DESCRIPTION
Closes #2 
Tested on my mac with a temporary wrapper - passed a different func to the metadata - and confirmed that ZJIT calls it successfully